### PR TITLE
close #4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,8 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
     let f = File::open(config.filename)?;
     let mut buff = BufReader::new(f);
 
-    for line in extract(&mut buff).lines() {
-        println!("{}", line);
-    }
+    let extracted_str = extract(&mut buff);
+    print!("{}", extracted_str);
 
     Ok(())
 }


### PR DESCRIPTION
why
・出力結果の末尾に改行が入ってしまうバグを改修するため
・文字列を返却してVectorに変換して文字列を出力するという無駄をなくすため

what
・出力マクロをprintln!からprint!に修正した
・extractの戻り値をそのままprintする実装とした